### PR TITLE
Project 2 [bug]: Increase width for numerical input field

### DIFF
--- a/app/assets/main/react_components/footprint_form/AnswerButton.jsx
+++ b/app/assets/main/react_components/footprint_form/AnswerButton.jsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
 
-const AnswerButton = ({ onAnswerGiven, label, isSelected, disableOnClick = false }) => {
-  let selectedClass = isSelected ? "button-cta " : "";
+const AnswerButton = ({ label, onAnswerGiven, disableOnClick = false, stylingClasses = "" }) => {
   const [disabled, setDisabled] = useState(false);
 
   return (
     <>
-      <button disabled={disabled} className={"button w-full " + selectedClass} 
+      <button disabled={disabled} className={"button whitespace-pre-wrap " + stylingClasses} 
         onClick={() => {
           if(disableOnClick)
             setDisabled(true);

--- a/app/assets/main/react_components/footprint_form/OptionList.jsx
+++ b/app/assets/main/react_components/footprint_form/OptionList.jsx
@@ -13,9 +13,9 @@ const OptionList = ({ onAnswerGiven, options, selectedKey }) => {
           return (
             <div key={key} className="my-3 flex-1">
               <AnswerButton 
-                onAnswerGiven={() => onAnswerGiven(key)} 
-                isSelected={selectedKey==key}
                 label={value} 
+                onAnswerGiven={() => onAnswerGiven(key)} 
+                stylingClasses={(selectedKey == key && "button-cta") + " w-full"}
               />
             </div>
           )

--- a/app/assets/main/react_components/footprint_form/OptionNumerical.jsx
+++ b/app/assets/main/react_components/footprint_form/OptionNumerical.jsx
@@ -33,7 +33,7 @@ const OptionNumerical = ({ onAnswerGiven, isCarOption, savedValue, onNumericalIn
 
   return (
     <div className="flex flex-col m-lg:flex-row" >
-      <label className="input mb-3 m-lg:mb-0 m-lg:mr-3 flex">
+      <label className="input mb-3 m-lg:mb-0 m-lg:mr-3 flex m-lg:w-1/3">
         <input autoFocus type="text" min="0" pattern="[0-9]+[.,]?[0-9]*" max="2147483647" size="7" className="flex-1" 
           value={value}
           onKeyPress = {(e) => onKeyPress(e)} 
@@ -43,11 +43,13 @@ const OptionNumerical = ({ onAnswerGiven, isCarOption, savedValue, onNumericalIn
       </label>
       <AnswerButton 
         label="Next"
-        disableOnClick={!isCarOption}
         onAnswerGiven={onAnswer}
+        disableOnClick={!isCarOption}
+        stylingClasses={"m-lg:w-2/3"}
       />
     </div>
   )
 }
 
 export default OptionNumerical;
+


### PR DESCRIPTION
Changed AnswerButton props so that all styling that differs between buttons for numerical and option buttons is passed as a single prop, since my new code introduced another styling case as selectedClass did. Otherwise we would have needed two props to calculate the styling internally.

Input width is not exactly as before, but I believe it looks good. Input field is given 1/3 of the width for medium and large screens, and the button is given 2/3. On small screens, they are given a row each like earlier solutions.