### PR TITLE
P1/feat/47 sidebar styling

### DIFF
--- a/app/assets/main/react_components/User/KanbanActionColumn.jsx
+++ b/app/assets/main/react_components/User/KanbanActionColumn.jsx
@@ -26,8 +26,11 @@ const KanbanActionColumn = ({
               style={{
                 background: snapshot.isDraggingOver ? "lightgrey" : "white",
                 padding: 4,
-                width: "auto",
-                minHeight: 500,
+                width: 410,
+                minHeight: 300,
+                maxHeight: 400,
+                overflowY: "scroll",
+                overflowX: "hidden",
               }}
             >
               {column.items.map((item, index) => {

--- a/app/assets/main/react_components/User/KanbanActionColumn.jsx
+++ b/app/assets/main/react_components/User/KanbanActionColumn.jsx
@@ -10,6 +10,7 @@ const KanbanActionColumn = ({
   setCollapsed,
   collapsed,
   categoryColor,
+  isHovering,
 }) => {
   return (
     <div className="h-full" key={columnId}>
@@ -23,7 +24,9 @@ const KanbanActionColumn = ({
           return (
             <div
               className={`h-full overflow-x-hidden ${
-                collapsed ? "overflow-y-hidden" : "overflow-y-scroll"
+                isHovering && !collapsed
+                  ? "overflow-y-auto"
+                  : "overflow-y-hidden"
               }`}
               {...provided.droppableProps}
               ref={provided.innerRef}

--- a/app/assets/main/react_components/User/KanbanActionColumn.jsx
+++ b/app/assets/main/react_components/User/KanbanActionColumn.jsx
@@ -36,19 +36,21 @@ const KanbanActionColumn = ({
                 width: 410,
               }}
             >
-              {column.items.map((item, index) => {
-                return (
-                  <KanbanActionItem
-                    item={item}
-                    index={index}
-                    key={item.id}
-                    handleDelete={handleDelete}
-                    handlePerformance={handlePerformance}
-                    collapsed={collapsed}
-                    categoryColor={categoryColor}
-                  />
-                );
-              })}
+              {column.items
+                .slice(0, collapsed ? 4 : column.items.length)
+                .map((item, index) => {
+                  return (
+                    <KanbanActionItem
+                      item={item}
+                      index={index}
+                      key={item.id}
+                      handleDelete={handleDelete}
+                      handlePerformance={handlePerformance}
+                      collapsed={collapsed}
+                      categoryColor={categoryColor}
+                    />
+                  );
+                })}
               {provided.placeholder}
             </div>
           );

--- a/app/assets/main/react_components/User/KanbanActionColumn.jsx
+++ b/app/assets/main/react_components/User/KanbanActionColumn.jsx
@@ -21,14 +21,15 @@ const KanbanActionColumn = ({
         {(provided, snapshot) => {
           return (
             <div
+              // className="h-1/2"
               {...provided.droppableProps}
               ref={provided.innerRef}
               style={{
                 background: snapshot.isDraggingOver ? "lightgrey" : "white",
                 padding: 4,
                 width: 410,
-                minHeight: 300,
-                maxHeight: 400,
+                // minHeight: 300,
+                maxHeight: 500,
                 overflowY: "scroll",
                 overflowX: "hidden",
               }}

--- a/app/assets/main/react_components/User/KanbanActionColumn.jsx
+++ b/app/assets/main/react_components/User/KanbanActionColumn.jsx
@@ -7,6 +7,7 @@ const KanbanActionColumn = ({
   columnId,
   handleDelete,
   handlePerformance,
+  setCollapsed,
   collapsed,
   categoryColor,
 }) => {
@@ -21,17 +22,15 @@ const KanbanActionColumn = ({
         {(provided, snapshot) => {
           return (
             <div
-              className="h-full"
+              className={`h-full overflow-x-hidden ${
+                collapsed ? "overflow-y-hidden" : "overflow-y-scroll"
+              }`}
               {...provided.droppableProps}
               ref={provided.innerRef}
               style={{
                 background: snapshot.isDraggingOver ? "lightgrey" : "white",
                 padding: 4,
                 width: 410,
-                // minHeight: 300,
-                // maxHeight: "full",
-                overflowY: "scroll",
-                overflowX: "hidden",
               }}
             >
               {column.items.map((item, index) => {
@@ -52,6 +51,21 @@ const KanbanActionColumn = ({
           );
         }}
       </Droppable>
+      {columnId === "1" && (
+        <div>
+          <hr
+            style={{
+              color: "lightgrey",
+            }}
+          ></hr>
+          <button
+            className={`fas rounded-full h-12 w-12 bg-white border border-gray-accent -left-6 -mt-6 absolute focus:outline-none ${
+              collapsed ? "fa-chevron-left" : "fa-chevron-right"
+            }`}
+            onClick={() => setCollapsed(!collapsed)}
+          ></button>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/assets/main/react_components/User/KanbanActionColumn.jsx
+++ b/app/assets/main/react_components/User/KanbanActionColumn.jsx
@@ -11,7 +11,7 @@ const KanbanActionColumn = ({
   categoryColor,
 }) => {
   return (
-    <div key={columnId}>
+    <div className="h-full" key={columnId}>
       <Droppable
         column={column}
         droppableId={columnId}
@@ -21,7 +21,7 @@ const KanbanActionColumn = ({
         {(provided, snapshot) => {
           return (
             <div
-              // className="h-1/2"
+              className="h-full"
               {...provided.droppableProps}
               ref={provided.innerRef}
               style={{
@@ -29,7 +29,7 @@ const KanbanActionColumn = ({
                 padding: 4,
                 width: 410,
                 // minHeight: 300,
-                maxHeight: 500,
+                // maxHeight: "full",
                 overflowY: "scroll",
                 overflowX: "hidden",
               }}

--- a/app/assets/main/react_components/User/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/User/KanbanActionContainer.jsx
@@ -204,7 +204,7 @@ const KanbanActionContainer = ({ collapsed, categoryColor }) => {
             // <div key={columnId}>
             // <div key={columnId}>
             <div
-              className="text-center pt-8 h-1/2"
+              className="text-center pt-8 h-1/2 pb-24 -mb-8"
               style={{ margin: 2 }}
               key={columnId}
             >

--- a/app/assets/main/react_components/User/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/User/KanbanActionContainer.jsx
@@ -195,20 +195,14 @@ const KanbanActionContainer = ({ collapsed, categoryColor }) => {
     }
   };
   return (
-    <div className="flex flex-col justify-center h-full">
+    <div className="flex flex-col justify-center top-0 h-screen">
       <DragDropContext
         onDragEnd={(result) => onDragEnd(result, columns, setColumns)}
       >
         {Object.entries(columns).map(([columnId, column]) => {
           return (
             <div key={columnId}>
-              <div
-                className="flex flex-col"
-                style={{
-                  alignItems: "center",
-                }}
-                key={columnId}
-              >
+              <div className="flex flex-col top-0" key={columnId}>
                 <div className="text-center pt-8" style={{ margin: 2 }}>
                   <p
                     className={`font-normal text-base text-primary text-lg top-0 text-center`}

--- a/app/assets/main/react_components/User/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/User/KanbanActionContainer.jsx
@@ -195,6 +195,7 @@ const KanbanActionContainer = ({ collapsed, categoryColor, setCollapsed }) => {
     }
   };
   const [isHovering, setIsHovering] = useState(false);
+
   return (
     <div className="h-screen">
       <DragDropContext

--- a/app/assets/main/react_components/User/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/User/KanbanActionContainer.jsx
@@ -9,7 +9,7 @@ import {
   useUserActionsColumnsWithFormatUpdate,
 } from "./contexts/UserActionsContext.js";
 
-const KanbanActionContainer = ({ collapsed, categoryColor }) => {
+const KanbanActionContainer = ({ collapsed, categoryColor, setCollapsed }) => {
   const setUserActions = useUserActionsUpdate();
   const columns = useUserActionsColumns();
   const setColumns = useUserActionsColumnsUpdate();
@@ -201,19 +201,18 @@ const KanbanActionContainer = ({ collapsed, categoryColor }) => {
       >
         {Object.entries(columns).map(([columnId, column]) => {
           return (
-            // <div key={columnId}>
-            // <div key={columnId}>
             <div
-              className="text-center pt-8 h-1/2 pb-24 -mb-8"
+              className="text-center h-1/2 pb-24 -mb-8"
               style={{ margin: 2 }}
               key={columnId}
             >
-              <p
-                className={`font-normal text-base text-primary text-lgtext-center`}
-              >
-                {!collapsed && column.name}
-              </p>
-
+              <div className="h-8">
+                <p
+                  className={`font-normal text-base text-primary text-lgtext-center`}
+                >
+                  {!collapsed && column.name}
+                </p>
+              </div>
               <KanbanActionColumn
                 column={column}
                 columnId={columnId}
@@ -221,11 +220,10 @@ const KanbanActionContainer = ({ collapsed, categoryColor }) => {
                 handleDelete={handleDelete}
                 handlePerformance={handlePerformance}
                 categoryColor={categoryColor}
+                setCollapsed={setCollapsed}
                 collapsed={collapsed}
               />
             </div>
-            // </div>
-            // </div>
           );
         })}
       </DragDropContext>

--- a/app/assets/main/react_components/User/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/User/KanbanActionContainer.jsx
@@ -195,33 +195,37 @@ const KanbanActionContainer = ({ collapsed, categoryColor }) => {
     }
   };
   return (
-    <div className="flex flex-col justify-center top-0 h-screen">
+    <div className="h-screen">
       <DragDropContext
         onDragEnd={(result) => onDragEnd(result, columns, setColumns)}
       >
         {Object.entries(columns).map(([columnId, column]) => {
           return (
-            <div key={columnId}>
-              <div className="flex flex-col top-0" key={columnId}>
-                <div className="text-center pt-8" style={{ margin: 2 }}>
-                  <p
-                    className={`font-normal text-base text-primary text-lg top-0 text-center`}
-                  >
-                    {!collapsed && column.name}
-                  </p>
+            // <div key={columnId}>
+            // <div key={columnId}>
+            <div
+              className="text-center pt-8"
+              style={{ margin: 2 }}
+              key={columnId}
+            >
+              <p
+                className={`font-normal text-base text-primary text-lgtext-center`}
+              >
+                {!collapsed && column.name}
+              </p>
 
-                  <KanbanActionColumn
-                    column={column}
-                    columnId={columnId}
-                    key={columnId}
-                    handleDelete={handleDelete}
-                    handlePerformance={handlePerformance}
-                    categoryColor={categoryColor}
-                    collapsed={collapsed}
-                  />
-                </div>
-              </div>
+              <KanbanActionColumn
+                column={column}
+                columnId={columnId}
+                key={columnId}
+                handleDelete={handleDelete}
+                handlePerformance={handlePerformance}
+                categoryColor={categoryColor}
+                collapsed={collapsed}
+              />
             </div>
+            // </div>
+            // </div>
           );
         })}
       </DragDropContext>

--- a/app/assets/main/react_components/User/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/User/KanbanActionContainer.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { DragDropContext } from "react-beautiful-dnd";
 import KanbanActionColumn from "./KanbanActionColumn.jsx";
 import { useUserActionsUpdate } from "./contexts/UserActionsContext.js";
@@ -194,6 +194,7 @@ const KanbanActionContainer = ({ collapsed, categoryColor, setCollapsed }) => {
       });
     }
   };
+  const [isHovering, setIsHovering] = useState(false);
   return (
     <div className="h-screen">
       <DragDropContext
@@ -205,6 +206,8 @@ const KanbanActionContainer = ({ collapsed, categoryColor, setCollapsed }) => {
               className="text-center h-1/2 pb-24 -mb-8"
               style={{ margin: 2 }}
               key={columnId}
+              onMouseEnter={() => setIsHovering(true)}
+              onMouseLeave={() => setIsHovering(false)}
             >
               <div className="h-8">
                 <p
@@ -222,6 +225,7 @@ const KanbanActionContainer = ({ collapsed, categoryColor, setCollapsed }) => {
                 categoryColor={categoryColor}
                 setCollapsed={setCollapsed}
                 collapsed={collapsed}
+                isHovering={isHovering}
               />
             </div>
           );

--- a/app/assets/main/react_components/User/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/User/KanbanActionContainer.jsx
@@ -204,7 +204,7 @@ const KanbanActionContainer = ({ collapsed, categoryColor }) => {
             // <div key={columnId}>
             // <div key={columnId}>
             <div
-              className="text-center pt-8"
+              className="text-center pt-8 h-1/2"
               style={{ margin: 2 }}
               key={columnId}
             >

--- a/app/assets/main/react_components/User/KanbanActionItem.jsx
+++ b/app/assets/main/react_components/User/KanbanActionItem.jsx
@@ -26,9 +26,10 @@ const KanbanActionItem = ({
       {(provided) => {
         return (
           <div
-            className={`${categoryColor} border border-gray-tint-2 rounded-lg shadow-lg p-4 h-full space-y-3 pt-0 ${
+            className={`${categoryColor} border border-gray-tint-2 rounded-lg shadow-lg p-4 space-y-3 pt-0 ${
               collapsed ? "w-24" : "w-96"
-            }`}
+            }
+            ${expanded ? "h-48" : "w-24"}`}
             ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}

--- a/app/assets/main/react_components/User/Sidebar.jsx
+++ b/app/assets/main/react_components/User/Sidebar.jsx
@@ -11,15 +11,11 @@ const Sidebar = () => {
           collapsed ? "w-28" : "w-auto"
         }`}
       >
-        <button
-          className={`fas rounded-full h-12 w-12 bg-white border border-gray-accent -ml-6 m-auto absolute bottom-1/2 focus:outline-none ${
-            collapsed ? "fa-chevron-left" : "fa-chevron-right"
-          }`}
-          onClick={() => setCollapsed(!collapsed)}
-        ></button>
-
         <div className={` ${collapsed ? "visible" : "visible"}`}>
-          <KanbanActionContainer collapsed={collapsed} />
+          <KanbanActionContainer
+            setCollapsed={setCollapsed}
+            collapsed={collapsed}
+          />
         </div>
       </div>
     </>

--- a/app/assets/main/react_components/User/contexts/UserActionsContext.js
+++ b/app/assets/main/react_components/User/contexts/UserActionsContext.js
@@ -57,12 +57,12 @@ export const UserActionsProvider = ({ children, allUserActions }) => {
     return {
       [1]: {
         id: "Accepted",
-        name: "Your accepted actions:",
+        name: "My Actions",
         items: acceptedList,
       },
       [2]: {
         id: "Performed",
-        name: "Your performed actions:",
+        name: "Achievements",
         items: doneList,
       },
     };


### PR DESCRIPTION
Sammanfattning:
* Grå linje som avskiljer mellan kanban-kolumnerna
* My actions" och "Achievements" ska ta upp halva skärmen var
* "Achievements" ska börja på den vertikala mitten av sidobaren oavsett hur mycket man zoomar in/ut
* Intern scroll I kanban-kolumnerna
* Bredden på sidebar är konstant oavsett om den innehåller actions eller inte
* Interna scrollers är endast synbara när man hovrar över sidebaren 
* Max 4 actions/badges per kolumn visas när sidebaren är ihopfälld