### PR TITLE
P1/feat/71 sidebar styling

### DIFF
--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionColumn.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionColumn.jsx
@@ -43,7 +43,7 @@ const KanbanActionColumn = ({
               ref={provided.innerRef}
               style={{
                 background: snapshot.isDraggingOver ? "lightgrey" : "white",
-                padding: 4,
+                padding: 0,
                 width: "100%",
               }}
             >

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionContainer.jsx
@@ -273,13 +273,12 @@ const KanbanActionContainer = ({ collapsed, setCollapsed, categories }) => {
         {Object.entries(columns).map(([columnId, column]) => {
           return (
             <div
-              className="text-center h-1/2 pb-24 -mb-8"
-              style={{ margin: 2 }}
+              className="text-center h-1/2 pb-24 -mb-10"
               key={columnId}
               onMouseEnter={() => setIsHovering(true)}
               onMouseLeave={() => setIsHovering(false)}
             >
-              <div className="h-8">
+              <div className="h-10">
                 <p
                   className={`font-normal text-base text-primary text-lg text-center`}
                 >

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
@@ -61,7 +61,7 @@ const KanbanActionItem = ({
       {(provided, snapshot) => {
         return (
           <div
-            className={`rounded-lg p-0 space-y-3 pt-0 w-80 mb-2 ${
+            className={`rounded-lg p-0 space-y-3 pt-0 w-80 mb-2 focus:outline-none ${
               collapsed ? "d:w-24" : "t:w-80 border border-gray-tint-2 mx-5"
             }
             
@@ -108,7 +108,7 @@ const KanbanActionItem = ({
                     ></div>
                   )}
                   <div
-                    className="flex flex-row h-16"
+                    className="flex flex-row h-auto"
                     onClick={() => handleExpanded(item, !item.expanded)}
                   >
                     <div className="flex flex-1">

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
@@ -81,7 +81,7 @@ const KanbanActionItem = ({
             {collapsed ? (
               <div className="flex flex-1 items-center justify-center shadow-md">
                 <div
-                  className={`rounded-full h-16 w-16 bg-cover shadow-lg`}
+                  className={`rounded-full h-16 w-16 bg-cover shadow-lg my-1`}
                   style={{
                     backgroundImage:
                       item.status === false

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
@@ -36,7 +36,6 @@ const KanbanActionItem = ({
       return {
         userSelect: "none",
         padding: 0,
-        margin: "0 0 8px 0",
         minHeight: "auto",
       };
     }
@@ -47,7 +46,6 @@ const KanbanActionItem = ({
     return {
       userSelect: "none",
       padding: 0,
-      margin: "0 0 8px 0",
       minHeight: "auto",
       ...style,
     };
@@ -63,8 +61,8 @@ const KanbanActionItem = ({
       {(provided, snapshot) => {
         return (
           <div
-            className={`border border-gray-tint-2 rounded-lg shadow-lg p-0 space-y-3 pt-0 w-80 ${
-              collapsed ? "d:w-24" : "t:w-80"
+            className={`rounded-lg p-0 space-y-3 pt-0 w-80 mb-2 ${
+              collapsed ? "d:w-24" : "t:w-80 border border-gray-tint-2 mx-4"
             }
             
             ${item.expanded ? "h-auto" : "w-24"}`}
@@ -83,7 +81,7 @@ const KanbanActionItem = ({
             {collapsed ? (
               <div className="flex flex-1 items-center justify-center shadow-md">
                 <div
-                  className={`rounded-full h-16 w-16 bg-cover`}
+                  className={`rounded-full h-16 w-16 bg-cover shadow-lg`}
                   style={{
                     backgroundImage:
                       item.status === false
@@ -167,7 +165,7 @@ const KanbanActionItem = ({
               <div className="mb-4 ml-7 mr-4">
                 {item.status === false ? (
                   <div className="flex flex-1 flex-col text-center">
-                    <div className="flex-1 justify-center">
+                    <div className="flex-1 justify-center text-left">
                       <p className="text-sm">
                         {item.description.length > 200
                           ? item.description.slice(0, 200) + "..."

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
@@ -164,7 +164,7 @@ const KanbanActionItem = ({
             )}
 
             {item.expanded && !collapsed && (
-              <div className="mb-4 mx-2">
+              <div className="mb-4 ml-7 mr-4">
                 {item.status === false ? (
                   <div className="flex flex-1 flex-col text-center">
                     <div className="flex-1 justify-center">
@@ -197,7 +197,7 @@ const KanbanActionItem = ({
                             {subitem.status === true ? (
                               <div className="group flex items-center mt-1 mb-3">
                                 <div
-                                  className="mr-3 rounded-full h-7 w-7 bg-cover flex-initial"
+                                  className="mr-3 rounded-full h-6 w-6 bg-cover flex-initial"
                                   style={{
                                     backgroundImage:
                                       "url('/achievement_images/AchievementStarActive.png')",
@@ -221,14 +221,14 @@ const KanbanActionItem = ({
                             ) : (
                               <div className="flex mt-1 mb-3">
                                 <div
-                                  className="mr-3 rounded-full h-7 w-7 bg-cover flex-initial"
+                                  className="mr-3 rounded-full h-6 w-6 bg-cover flex-initial"
                                   style={{
                                     backgroundImage:
                                       "url('/achievement_images/AchievementStarInactive.png')",
                                   }}
                                 ></div>
                                 <div
-                                  className={`flex-inital text-left text-gray-accent text-sm
+                                  className={`text-sm flex-inital text-left text-gray-accent
                                   `}
                                 >
                                   {subitem.name}
@@ -246,14 +246,14 @@ const KanbanActionItem = ({
                       <div key={subitem.id}>
                         <div className="flex mt-1 mb-3">
                           <div
-                            className="mr-3 rounded-full h-7 w-7 bg-cover flex-initial"
+                            className="mr-3 rounded-full h-6 w-6 bg-cover flex-initial"
                             style={{
                               backgroundImage:
                                 "url('/achievement_images/AchievementStarInactive.png')",
                             }}
                           ></div>
                           <div
-                            className={`flex-inital text-left text-gray-accent text-sm"
+                            className={`text-sm flex-inital text-left text-gray-accent"
                             `}
                           >
                             {subitem.name}

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/ProgressBar.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/ProgressBar.jsx
@@ -36,7 +36,7 @@ const ProgressBar = ({ categories, item, userActions, actions }) => {
         ></div>
       </div>
 
-      <span className="ml-5">{`${completed + "/" + total}`}</span>
+      <span className="ml-5 text-sm">{`${completed + "/" + total}`}</span>
     </div>
   );
 };

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/sidebar/Sidebar.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/sidebar/Sidebar.jsx
@@ -7,7 +7,7 @@ const Sidebar = ({ children, collapsed }) => {
 
   return ReactDom.createPortal(
     <>
-      <div className={`${collapsed ? "w-28" : "w-auto"}`}>{children}</div>
+      <div className={`${collapsed ? "w-24" : "w-auto"}`}>{children}</div>
     </>,
     document.querySelector("#sidebar")
   );

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -238,7 +238,7 @@
 
   <%= render "shared/bottom_landscape" %>
 </div>
-<div id="sidebar" class="sticky float-right bg-white h-screen w-auto top-20 z-10 border-l border-gray-accent"></div> 
+<div id="sidebar" class="sticky float-right bg-white h-screen w-auto top-20 z-10 shadow"></div> 
 
 </div>
 


### PR DESCRIPTION
Commit sammanfattning:
* Padding på items (mer utrymme mellan sidobaren och varje item)
* Stjärnorna i categoryBadges börjar i höjd med där badgen börjar (padding)
* Fixa samma storlek på text i achievements
* Ta bort border på items i infällt läge
* Lägg till tint på ramen på bilderna i infällt läge
* Minska bredden på infälld sidobar
* Shadow på sidobaren (vertikalt längs med hela sidobaren)
* Vänster-align text i actions
* Minska top padding för achievements
* Fixa så ofärdiga actions i achievements har samma grå text
* Fixa kryss synligt endast on hover
* Tog bort outline on focus