### PR TITLE
P1/fix/kanban width and progress bar position

### DIFF
--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionContainer.jsx
@@ -297,7 +297,7 @@ const KanbanActionContainer = ({ collapsed, setCollapsed, categories }) => {
             >
               <div className="h-10">
                 <p
-                  className={`font-normal text-base text-primary text-lg text-center`}
+                  className={`font-normal text-base text-primary text-lg text-center mx-28`}
                 >
                   {!collapsed && column.name}
                 </p>

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionContainer.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionContainer.jsx
@@ -295,9 +295,9 @@ const KanbanActionContainer = ({ collapsed, setCollapsed, categories }) => {
               onMouseEnter={() => setIsHovering(true)}
               onMouseLeave={() => setIsHovering(false)}
             >
-              <div className="h-10">
+              <div className="h-10" style={{ width: 360 }}>
                 <p
-                  className={`font-normal text-base text-primary text-lg text-center mx-28`}
+                  className={`font-normal text-base text-primary text-lg text-center`}
                 >
                   {!collapsed && column.name}
                 </p>

--- a/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
+++ b/app/assets/main/react_components/dashboard/climate_actions/manage_actions/kanban/KanbanActionItem.jsx
@@ -139,7 +139,7 @@ const KanbanActionItem = ({
                     <div className="flex flex-1 justify-center items-start">
                       <button
                         className={`fas float-right focus:outline-none ${
-                          isBadge ? "mt-12 ml-10" : "mt-4 ml-4"
+                          isBadge ? "mt-9 ml-4" : "mt-4 ml-4"
                         } ${
                           item.expanded ? "fa-chevron-up" : "fa-chevron-down"
                         }`}
@@ -148,7 +148,7 @@ const KanbanActionItem = ({
                     </div>
                   </div>
                   {isBadge && (
-                    <div className="flex justify-center ml-6 -mt-4">
+                    <div className="flex justify-center ml-6 -mt-7">
                       <ProgressBar
                         categories={categories}
                         item={item}


### PR DESCRIPTION
Simple changes! 

Added margin to the column headers to achieve the same width for sidebar when empty. It is not the exact width due to tailwind only accepting mx-28 and mx-32 when perhaps mx-29 would have been the best. Does anyone have a better solution?


